### PR TITLE
Make node traversal APIs more type-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,3 @@ categories = ["data-structures"]
 
 edition = "2021"
 rust-version = "1.56"
-
-[features]
-default = ["log"]
-
-[dependencies]
-log = { version = "0.4.8", optional = true }

--- a/src/map/mod.rs
+++ b/src/map/mod.rs
@@ -237,14 +237,14 @@ impl<K, V> AATreeMap<K, V> {
 		Q: Ord + ?Sized
 	{
 		self.root
-			.traverse(|content, sub| match sub {
-				Some(sub) => sub,
-				None => match content.key.borrow().cmp(k) {
+			.traverse(
+				|content| match content.key.borrow().cmp(k) {
 					Ordering::Greater => TraverseStep::Left,
 					Ordering::Less => TraverseStep::Right,
 					Ordering::Equal => TraverseStep::Value(Some(()))
-				}
-			})
+				},
+				|_, sub| sub
+			)
 			.is_some()
 	}
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -5,10 +5,8 @@ use alloc::boxed::Box;
 use core::mem;
 
 mod insert;
-pub use insert::*;
 
 mod remove;
-pub use remove::*;
 
 mod traverse;
 pub use traverse::*;


### PR DESCRIPTION
The callback that was previously being passed to `AANode::traverse` had to operate in two entirely distinct modes, one for when it was being called on the way down and one for going back up. Mixing the two together led to an extra match inside everything passed as a callback and meant the implementation had to deal with extra cases that could never happen. Separating it into two callbacks allows all of that to be cleaned up, meaning that it is no longer possible for the callback(s) to return an inappropriate value and that we don't need a dependency on the `log` crate for the bad case.

`traverse_mut` also gets a limited version of the same change applied; since it doesn't call any callbacks on the way up, there is no second callback to add, but we can statically ensure that a direction is never returned at the top level.

----

The benchmarks showed regressions of 10-15% on the Contains runs but similarly sized gains on the Remove runs. That is unfortunate considering that (I would guess) most workloads will have more containment checks than removals; I would say that the better API is well worth it. but that's your call, of course. I haven't looked deeply into whether this version could be optimized, but I considered it briefly and nothing jumped out at me.

For some reason, I had to remove the `pub use` lines in `src/node/mod.rs` to avoid failing compilation due to `unreachable_pub`. The functions in those modules still appear in the public API according to `cargo doc`, so I just left those changes in the PR.