### PR TITLE
Fix `(first|last)_key_value_mut_at_or_(after|before)`

### DIFF
--- a/src/map/get.rs
+++ b/src/map/get.rs
@@ -337,7 +337,7 @@ mod tests {
 	use crate::AATreeMap;
 
 	#[test]
-	fn test_first_key_value_mut_at_or_after() {
+	fn test_first_key_value() {
 		let mut map = AATreeMap::new();
 		map.insert(10, "a");
 		map.insert(20, "b");
@@ -355,13 +355,16 @@ mod tests {
 		// 10  30  50  70
 
 		// To return the correct value for 15, we need to go left once but not twice
+		let (key, value) = map.first_key_value_at_or_after(&15).unwrap();
+		assert_eq!(*key, 20);
+		assert_eq!(*value, "b");
 		let (key, value) = map.first_key_value_mut_at_or_after(&15).unwrap();
 		assert_eq!(*key, 20);
 		assert_eq!(*value, "b");
 	}
 
 	#[test]
-	fn test_last_key_value_mut_at_or_before() {
+	fn test_last_key_value() {
 		let mut map = AATreeMap::new();
 		map.insert(10, "a");
 		map.insert(20, "b");
@@ -374,6 +377,9 @@ mod tests {
 		// 10         40
 
 		// To return the correct value for 35, we need to go right once but not twice
+		let (key, value) = map.last_key_value_at_or_before(&35).unwrap();
+		assert_eq!(*key, 30);
+		assert_eq!(*value, "c");
 		let (key, value) = map.last_key_value_mut_at_or_before(&35).unwrap();
 		assert_eq!(*key, 30);
 		assert_eq!(*value, "c");

--- a/src/map/kv.rs
+++ b/src/map/kv.rs
@@ -17,6 +17,10 @@ impl<K, V> KeyValue<K, V> {
 		(&self.key, &self.value)
 	}
 
+	pub(super) fn as_tuple_mut(&mut self) -> (&K, &mut V) {
+		(&self.key, &mut self.value)
+	}
+
 	pub(super) fn into_tuple(self) -> (K, V) {
 		(self.key, self.value)
 	}

--- a/src/node/traverse.rs
+++ b/src/node/traverse.rs
@@ -8,16 +8,10 @@ pub enum TraverseStep<R> {
 	Value(Option<R>)
 }
 
-pub(crate) struct TraverseMutContext(bool, bool);
-
-impl TraverseMutContext {
-	pub(crate) fn has_left_child(&self) -> bool {
-		self.0
-	}
-
-	pub(crate) fn has_right_child(&self) -> bool {
-		self.1
-	}
+#[derive(Debug)]
+pub(crate) struct TraverseMutContext {
+	pub(crate) has_left_child: bool,
+	pub(crate) has_right_child: bool
 }
 
 impl<T> AANode<T> {
@@ -75,13 +69,16 @@ impl<T> AANode<T> {
 			 }| {
 				match (left_child.is_nil(), right_child.is_nil()) {
 					(true, true) => leaf_callback(content),
-					(left, right) => {
-						let child =
-							match callback(content, TraverseMutContext(left, right)) {
-								TraverseStep::Left => left_child,
-								TraverseStep::Right => right_child,
-								TraverseStep::Value(val) => return val
-							};
+					(left_is_nil, right_is_nil) => {
+						let ctx = TraverseMutContext {
+							has_left_child: !left_is_nil,
+							has_right_child: !right_is_nil
+						};
+						let child = match callback(content, ctx) {
+							TraverseStep::Left => left_child,
+							TraverseStep::Right => right_child,
+							TraverseStep::Value(val) => return val
+						};
 						child.traverse_mut(callback, leaf_callback)
 					}
 				}

--- a/src/node/traverse.rs
+++ b/src/node/traverse.rs
@@ -1,4 +1,5 @@
 use super::{AANode, Node};
+use core::fmt::{self, Display, Formatter};
 
 /// This type specifies the requested step for [`traverse`](AANode::traverse).
 #[derive(Debug)]
@@ -6,12 +7,6 @@ pub enum TraverseStep<R> {
 	Left,
 	Right,
 	Value(Option<R>)
-}
-
-#[derive(Debug)]
-pub(crate) struct TraverseMutContext {
-	pub(crate) has_left_child: bool,
-	pub(crate) has_right_child: bool
 }
 
 impl<T> AANode<T> {
@@ -46,43 +41,108 @@ impl<T> AANode<T> {
 			}
 		)
 	}
+}
 
+pub(crate) struct TraverseMutError(&'static str);
+
+impl Display for TraverseMutError {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		write!(f, "Attempt to turn {} but there is no such child", self.0)
+	}
+}
+
+pub(crate) struct TraverseMut<'a, T> {
+	node: &'a mut AANode<T>
+}
+
+#[allow(dead_code)] // I might need that in the future
+impl<'a, T> TraverseMut<'a, T> {
+	/// Return if this node is a leaf (i.e. it is not nil and has no children).
+	pub(crate) fn is_leaf(&self) -> bool {
+		self.node.is_leaf()
+	}
+
+	/// Peek the content of this node (unless it is nil).
+	pub(crate) fn peek(&self) -> &T {
+		&self
+			.node
+			.as_ref()
+			.expect("This node should not be nil")
+			.content
+	}
+
+	/// Return the content of this node (unless it is nil).
+	pub(crate) fn into_content(self) -> &'a mut T {
+		&mut self
+			.node
+			.as_mut()
+			.expect("This node should not be nil")
+			.content
+	}
+
+	/// Return if this node has a left child.
+	pub(crate) fn has_left_child(&self) -> bool {
+		self.node
+			.as_ref()
+			.map(|node| !node.left_child.is_nil())
+			.unwrap_or(false)
+	}
+
+	/// Peek the content of the left child.
+	pub(crate) fn peek_left_child(&self) -> Option<&T> {
+		self.node
+			.as_ref()
+			.and_then(|node| node.left_child.as_ref().map(|left| &left.content))
+	}
+
+	/// Continue traversing the tree with the left child of the current node.
+	pub(crate) fn turn_left(self) -> Result<Self, TraverseMutError> {
+		Ok(Self {
+			node: self
+				.node
+				.as_mut()
+				.and_then(|node| {
+					(!node.left_child.is_nil()).then_some(&mut node.left_child)
+				})
+				.ok_or(TraverseMutError("left"))?
+		})
+	}
+
+	/// Return if this node has a right child.
+	pub(crate) fn has_right_child(&self) -> bool {
+		self.node
+			.as_ref()
+			.map(|node| !node.right_child.is_nil())
+			.unwrap_or(false)
+	}
+
+	/// Peek the content of the left child.
+	pub(crate) fn peek_right_child(&self) -> Option<&T> {
+		self.node
+			.as_ref()
+			.and_then(|node| node.right_child.as_ref().map(|left| &left.content))
+	}
+
+	/// Continue traversing the tree with the left child of the current node.
+	pub(crate) fn turn_right(self) -> Result<Self, TraverseMutError> {
+		Ok(Self {
+			node: self
+				.node
+				.as_mut()
+				.and_then(|node| {
+					(!node.right_child.is_nil()).then_some(&mut node.right_child)
+				})
+				.ok_or(TraverseMutError("right"))?
+		})
+	}
+}
+
+impl<T> AANode<T> {
 	/// Traverse the tree, allowing for mutation of the nodes that are being traversed.
 	///
 	/// **It is a logic error to mutate the nodes in a way that changes their order with
 	/// respect to the other nodes in the tree.**
-	pub(crate) fn traverse_mut<'a, F, L, R>(
-		&'a mut self,
-		callback: F,
-		leaf_callback: L
-	) -> Option<R>
-	where
-		F: Fn(&'a mut T, TraverseMutContext) -> TraverseStep<R> + Copy,
-		L: Fn(&'a mut T) -> Option<R>
-	{
-		self.as_mut().and_then(
-			|Node {
-			     content,
-			     left_child,
-			     right_child,
-			     ..
-			 }| {
-				match (left_child.is_nil(), right_child.is_nil()) {
-					(true, true) => leaf_callback(content),
-					(left_is_nil, right_is_nil) => {
-						let ctx = TraverseMutContext {
-							has_left_child: !left_is_nil,
-							has_right_child: !right_is_nil
-						};
-						let child = match callback(content, ctx) {
-							TraverseStep::Left => left_child,
-							TraverseStep::Right => right_child,
-							TraverseStep::Value(val) => return val
-						};
-						child.traverse_mut(callback, leaf_callback)
-					}
-				}
-			}
-		)
+	pub(crate) fn traverse_mut(&mut self) -> Option<TraverseMut<'_, T>> {
+		(!self.is_nil()).then(|| TraverseMut { node: self })
 	}
 }

--- a/src/node/traverse.rs
+++ b/src/node/traverse.rs
@@ -1,5 +1,5 @@
 use super::{AANode, Node};
-use core::fmt::{self, Display, Formatter};
+use core::fmt::{self, Debug, Display, Formatter};
 
 /// This type specifies the requested step for [`traverse`](AANode::traverse).
 #[derive(Debug)]
@@ -48,6 +48,12 @@ pub(crate) struct TraverseMutError(&'static str);
 impl Display for TraverseMutError {
 	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
 		write!(f, "Attempt to turn {} but there is no such child", self.0)
+	}
+}
+
+impl Debug for TraverseMutError {
+	fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+		Display::fmt(self, f)
 	}
 }
 

--- a/src/node/traverse.rs
+++ b/src/node/traverse.rs
@@ -108,7 +108,7 @@ impl<'a, T> TraverseMut<'a, T> {
 				.node
 				.as_mut()
 				.and_then(|node| {
-					(!node.left_child.is_nil()).then_some(&mut node.left_child)
+					(!node.left_child.is_nil()).then(|| &mut node.left_child)
 				})
 				.ok_or(TraverseMutError("left"))?
 		})
@@ -136,7 +136,7 @@ impl<'a, T> TraverseMut<'a, T> {
 				.node
 				.as_mut()
 				.and_then(|node| {
-					(!node.right_child.is_nil()).then_some(&mut node.right_child)
+					(!node.right_child.is_nil()).then(|| &mut node.right_child)
 				})
 				.ok_or(TraverseMutError("right"))?
 		})


### PR DESCRIPTION
**Note:** The `first_key_value_at_or_after` and `last_key_value_at_or_after` functions are not affected.

The `first_key_value_mut_at_or_after` and `last_key_value_mut_at_or_before` functions don't return correct results. I discovered this by accident, looks like nobody is actually using these functions.